### PR TITLE
upd: prefix for index name, to allow several craft projects and one e…

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -29,6 +29,11 @@ class Settings extends Model
     /** @var string [optional] The password used to connect to the Elasticsearch server */
     public $password = 'MagicWord';
 
+    /** @var string [optional] Prefix that could be used to customize index name to have
+     * possibility to use same elastic instance with several craft instances
+     */
+    public $indexNamePrefix;
+    
     /** @var bool A boolean indicating whether authentication to the Elasticsearch server is required */
     public $isAuthEnabled = false;
 

--- a/src/records/ElasticsearchRecord.php
+++ b/src/records/ElasticsearchRecord.php
@@ -255,7 +255,16 @@ class ElasticsearchRecord extends ActiveRecord
         if (static::$siteId === null) {
             throw new InvalidConfigException('siteId was not set');
         }
-        return 'craft-entries_' . static::$siteId;
+
+        $elasticIndexNamePrefix = ElasticsearchPlugin::getInstance()->getSettings()->indexNamePrefix;
+
+        $indexName = 'craft-entries_' . static::$siteId;
+
+        if($elasticIndexNamePrefix !== null){
+            $indexName = $elasticIndexNamePrefix . '_' .  $indexName;
+        }
+
+        return $indexName;
     }
 
     /**


### PR DESCRIPTION
If there are few craft projects at same server that we want to use with craft-elasticsearch it's a problem to do this because index name is the same for all projects and this wouldn't work correctly.
I propose small update that will help to use plugin for different projects at same server. In my case we need this update and i want to pull it right after release with it(or at least some similar solution).
Or if you have some another solution how to use own index for project please let me know.