### PR TITLE
Add support for Digital Products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elasticsearch plugin for Craft CMS 3.x Changelog
 
+## 1.5.0
+### Added
+- Ability to index digital products
+
 ## 1.4.0 - 2020-10-02
 ### Added
 - Ability to index assets

--- a/src/Elasticsearch.php
+++ b/src/Elasticsearch.php
@@ -14,6 +14,7 @@ use Craft;
 use craft\base\Element;
 use craft\base\Plugin;
 use craft\commerce\elements\Product;
+use craft\digitalproducts\elements\Product as DigitalProduct;
 use craft\console\Application as ConsoleApplication;
 use craft\elements\Asset;
 use craft\elements\Entry;
@@ -64,6 +65,7 @@ class Elasticsearch extends Plugin
     {
         parent::init();
         $isCommerceEnabled = $this->isCommerceEnabled();
+		$isDigitalProductsEnabled = $this->isDigitalProductsEnabled();
 
         $this->setComponents(
             [
@@ -103,6 +105,9 @@ class Elasticsearch extends Plugin
             if ($isCommerceEnabled) {
                 Event::on(Product::class, Product::EVENT_AFTER_SAVE, [$this, 'onElementSaved']);
             }
+			if ($isDigitalProductsEnabled) {
+				Event::on(DigitalProduct::class, DigitalProduct::EVENT_AFTER_SAVE, [$this, 'onElementSaved']);
+			}
 
             // Re-index all entries when plugin settings are saved
             Event::on(
@@ -345,6 +350,16 @@ class Elasticsearch extends Plugin
     {
         return class_exists(\craft\commerce\Plugin::class);
     }
+
+	/**
+     * Check for presence of Craft Digital Products Plugin
+     * @return bool
+     */
+    public function isDigitalProductsEnabled(): bool
+    {
+        return class_exists(\craft\digitalproducts\Plugin::class);
+    }
+
 
     /**
      * @param ModelEvent $event

--- a/src/console/controllers/ElasticsearchController.php
+++ b/src/console/controllers/ElasticsearchController.php
@@ -33,7 +33,7 @@ class ElasticsearchController extends Controller
     }
 
     /**
-     * Reindex entries, assets & products in Elasticsearch
+     * Reindex entries, assets, products & digital products in Elasticsearch
      * @return int A shell exit code. 0 indicates success, anything else indicates an error
      * @throws IndexElementException
      * @throws \GuzzleHttp\Exception\GuzzleException
@@ -99,6 +99,24 @@ class ElasticsearchController extends Controller
 
         return $this->reindexElements($elementDescriptors, 'products');
     }
+
+    /**
+     * Reindex digital products in Elasticsearch
+     * @return int A shell exit code. 0 indicates success, anything else indicates an error
+     * @throws IndexElementException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \yii\base\InvalidConfigException
+     * @throws \yii\db\Exception
+     * @throws \yii\db\StaleObjectException
+     * @throws \yii\elasticsearch\Exception
+     */
+    public function actionReindexDigitalProducts(): int
+    {
+        $elementDescriptors = $this->plugin->service->getIndexableDigitalProductModels();
+
+        return $this->reindexElements($elementDescriptors, 'digitalProducts');
+    }
+
 
     /**
      * Remove index & create an empty one for all sites

--- a/src/controllers/CpController.php
+++ b/src/controllers/CpController.php
@@ -11,7 +11,6 @@
 namespace lhs\elasticsearch\controllers;
 
 use Craft;
-use craft\commerce\elements\Product;
 use craft\helpers\UrlHelper;
 use craft\records\Site;
 use craft\web\Controller;

--- a/src/exceptions/IndexableElementModelException.php
+++ b/src/exceptions/IndexableElementModelException.php
@@ -10,6 +10,8 @@ class IndexableElementModelException extends Exception
     public const ELEMENT_NOT_FOUND = 0;
     public const CRAFT_COMMERCE_NOT_INSTALLED = 1;
     public const UNEXPECTED_TYPE = 2;
+	public const DIGITAL_PRODUCTS_NOT_INSTALLED = 3;
+
 
     public function __construct(IndexableElementModel $model, $code, Throwable $previous = null)
     {
@@ -21,6 +23,13 @@ class IndexableElementModelException extends Exception
                     $model->siteId
                 );
                 break;
+			case self::DIGITAL_PRODUCTS_NOT_INSTALLED:
+				$message = sprintf(
+					"Element #%d (site #%d) is a digital product but the Digital Products plugin isn't installed.",
+					$model->elementId,
+					$model->siteId
+				);
+				break;
             case self::ELEMENT_NOT_FOUND:
                 $message = sprintf(
                     'Element #%d (site #%d) not found (type: %s)',

--- a/src/jobs/IndexElementJob.php
+++ b/src/jobs/IndexElementJob.php
@@ -11,7 +11,6 @@
 namespace lhs\elasticsearch\jobs;
 
 use Craft;
-use craft\commerce\elements\Product;
 use craft\queue\BaseJob;
 use lhs\elasticsearch\Elasticsearch;
 use lhs\elasticsearch\models\IndexableElementModel;

--- a/src/models/IndexableElementModel.php
+++ b/src/models/IndexableElementModel.php
@@ -5,6 +5,7 @@ namespace lhs\elasticsearch\models;
 use Craft;
 use craft\base\Element;
 use craft\commerce\elements\Product;
+use craft\digitalproducts\elements\Product as DigitalProduct;
 use craft\elements\Asset;
 use craft\elements\Entry;
 use lhs\elasticsearch\exceptions\IndexableElementModelException;
@@ -33,6 +34,13 @@ class IndexableElementModel extends \craft\base\Model implements \JsonSerializab
                 }
                 $element = $commercePlugin->getProducts()->getProductById($this->elementId, $this->siteId);
                 break;
+			case DigitalProduct::class:
+				$digitalProductsPlugin = craft\digitalproducts\Plugin::getInstance();
+				if (!$digitalProductsPlugin) {
+					throw new IndexableElementModelException($this, IndexableElementModelException::DIGITAL_PRODUCTS_NOT_INSTALLED);
+				}
+				$element = Craft::$app->getElements()->getElementById($this->elementId, DigitalProduct::class, $this->siteId);
+				break;
             case Entry::class:
                 $element = Craft::$app->getEntries()->getEntryById($this->elementId, $this->siteId);
                 break;

--- a/src/services/ElasticsearchService.php
+++ b/src/services/ElasticsearchService.php
@@ -17,6 +17,7 @@ namespace lhs\elasticsearch\services;
 use Craft;
 use craft\base\Component;
 use craft\commerce\elements\Product;
+use craft\digitalproducts\elements\Product as DigitalProduct;
 use craft\elements\Asset;
 use craft\elements\Entry;
 use craft\errors\SiteNotFoundException;
@@ -236,6 +237,9 @@ class ElasticsearchService extends Component
         if ($this->plugin->isCommerceEnabled()) {
             $models = ArrayHelper::merge($models, $this->getIndexableProductModels($siteIds));
         }
+		if ($this->plugin->isDigitalProductsEnabled()) {
+			$models = ArrayHelper::merge($models, $this->getIndexableDigitalProductModels($siteIds));
+		}
 
         return $models;
     }
@@ -306,6 +310,40 @@ class ElasticsearchService extends Component
         );
     }
 
+	/**
+     * Return a list of enabled digital products an array of elements descriptors
+     * @param int[]|null $siteIds An array containing the ids of sites to be or
+     *                            reindexed, or `null` to reindex all sites.
+     * @return array An array of elements descriptors. An entry descriptor is an
+     *                            associative array with the `elementId` and `siteId` keys.
+     */
+    public function getIndexableDigitalProductModels($siteIds = null): array
+    {
+        if ($siteIds === null) {
+            $siteIds = Craft::$app->getSites()->getAllSiteIds();
+        }
+
+        $digitalProducts = [];
+        foreach ($siteIds as $siteId) {
+            $siteEntries = $this->getIndexableDigitalProductsQuery($siteId)
+                ->select(['digitalproducts_products.id as elementId', 'elements_sites.siteId'])
+                ->asArray(true)
+                ->all();
+            $digitalProducts = ArrayHelper::merge($digitalProducts, $siteEntries);
+        }
+
+        return array_map(
+            static function ($entry): IndexableElementModel {
+                $model = new IndexableElementModel();
+                $model->elementId = $entry['elementId'];
+                $model->siteId = $entry['siteId'];
+                $model->type = DigitalProduct::class;
+                return $model;
+            },
+            $digitalProducts
+        );
+    }
+
     /**
      * Return a list of enabled assets as an array of elements descriptors
      * @param int[]|null $siteIds An array containing the ids of sites to be or reindexed, or `null` to reindex all sites.
@@ -364,6 +402,14 @@ class ElasticsearchService extends Component
             ->uri(['not', '']);
     }
 
+	public function getIndexableDigitalProductsQuery($siteId)
+    {
+        return DigitalProduct::find()
+            ->status([Entry::STATUS_PENDING, Entry::STATUS_LIVE])
+            ->siteId($siteId)
+            ->uri(['not', '']);
+    }
+
     public static function getSyncCachekey(): string
     {
         return self::class . '_isSync';
@@ -394,6 +440,9 @@ class ElasticsearchService extends Component
         if ($this->plugin->isCommerceEnabled()) {
             $countProducts = (int)$this->getIndexableProductsQuery($siteId)->count();
         }
-        return $countEntries + $countAssets + ($countProducts ?? 0);
+		if ($this->plugin->isDigitalProductsEnabled()) {
+			$countDigitalProducts = (int)$this->getIndexableDigitalProductsQuery($siteId)->count();
+		}
+        return $countEntries + $countAssets + ($countProducts ?? 0) + ($countDigitalProducts ?? 0);
     }
 }

--- a/src/services/ElementIndexerService.php
+++ b/src/services/ElementIndexerService.php
@@ -14,6 +14,7 @@ use Craft;
 use craft\base\Component;
 use craft\base\Element;
 use craft\commerce\elements\Product;
+use craft\digitalproducts\elements\Product as DigitalProduct;
 use craft\elements\Asset;
 use craft\elements\Entry;
 use craft\errors\SiteNotFoundException;
@@ -116,9 +117,10 @@ class ElementIndexerService extends Component
         if (!(
             $element instanceof Entry
             || $element instanceof Product
+			|| $element instanceof DigitalProduct
             || $element instanceof Asset
         )) {
-            $message = "Not indexing entry #{$element->id} since it is not an entry, an asset or a product.";
+            $message = "Not indexing entry #{$element->id} since it is not an entry, an asset, a product or a digital product.";
             Craft::debug($message, __METHOD__);
             return $message;
         }
@@ -207,7 +209,7 @@ class ElementIndexerService extends Component
                     ['productId' => $element->id, 'siteId' => $element->siteId],
                 ]
             );
-        } else {
+		} else {
             $schemaVersion = Craft::$app->getInstalledSchemaVersion();
             if (version_compare($schemaVersion, '3.2.0', '>=')) {
                 $token = Craft::$app->getTokens()->createToken(


### PR DESCRIPTION
Hi,

thank you for the great plugin! 

In our shop, we are using Pixel&Tonics [Digital Products](https://plugins.craftcms.com/digital-products) extension and need to index them along with regular Craft Commerce Products. 

This pull request adds support for Digital Products.

Please let me know what you think, it would be nice if we can include this feature into your extension.

cheers
