### PR TITLE
Update analyser for polish

### DIFF
--- a/src/records/ElasticsearchRecord.php
+++ b/src/records/ElasticsearchRecord.php
@@ -190,7 +190,7 @@ class ElasticsearchRecord extends ActiveRecord
             'cs'    => 'czech',
             'da'    => 'danish',
             'nl'    => 'dutch',
-            'pl'    => 'stempel', // analysis-stempel plugin needed
+            'pl'    => 'polish', // analysis-stempel plugin needed
             'en'    => 'english',
             'fi'    => 'finnish',
             'fr'    => 'french',


### PR DESCRIPTION
In order to prevent an indexing error like "analyzer [stempel] not found for field xy", we have to change the polish analyser from "stempel" to "polish". After this change, all indexer works find.

Tested with version 1.5 and Craft 3.7.47.